### PR TITLE
fix: don't update the Pod after it's been created

### DIFF
--- a/controllers/base_request_controller_test.go
+++ b/controllers/base_request_controller_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,7 +36,7 @@ var _ = Describe("BaseRequestReconciler", Ordered, func() {
 			r = &BaseRequestReconciler{
 				BaseReconciler: BaseReconciler{
 					Client:                  fakeClient,
-					Scheme:                  &runtime.Scheme{},
+					Scheme:                  fakeClient.Scheme(),
 					APIReader:               fakeClient,
 					ReconcililationInterval: 0,
 				},
@@ -66,7 +65,6 @@ var _ = Describe("BaseRequestReconciler", Ordered, func() {
 				BaseBuilder: builders.BaseBuilder{
 					Client:    fakeClient,
 					Ctx:       ctx,
-					Scheme:    &runtime.Scheme{},
 					APIReader: fakeClient,
 					Request:   request,
 				},
@@ -175,7 +173,7 @@ var _ = Describe("BaseRequestReconciler", Ordered, func() {
 			r = &BaseRequestReconciler{
 				BaseReconciler: BaseReconciler{
 					Client:                  fakeClient,
-					Scheme:                  &runtime.Scheme{},
+					Scheme:                  fakeClient.Scheme(),
 					APIReader:               fakeClient,
 					ReconcililationInterval: 0,
 				},
@@ -216,7 +214,6 @@ var _ = Describe("BaseRequestReconciler", Ordered, func() {
 			builder = &builders.BaseBuilder{
 				Client:    fakeClient,
 				Ctx:       ctx,
-				Scheme:    &runtime.Scheme{},
 				APIReader: fakeClient,
 				Request:   request,
 			}
@@ -261,7 +258,6 @@ var _ = Describe("BaseRequestReconciler", Ordered, func() {
 			builder = &builders.BaseBuilder{
 				Client:    fakeClient,
 				Ctx:       ctx,
-				Scheme:    &runtime.Scheme{},
 				APIReader: fakeClient,
 				Request:   request,
 			}
@@ -309,7 +305,6 @@ var _ = Describe("BaseRequestReconciler", Ordered, func() {
 			builder = &builders.BaseBuilder{
 				Client:    fakeClient,
 				Ctx:       ctx,
-				Scheme:    &runtime.Scheme{},
 				APIReader: fakeClient,
 				Request:   request,
 			}
@@ -365,7 +360,7 @@ var _ = Describe("BaseRequestReconciler", Ordered, func() {
 			r = &BaseRequestReconciler{
 				BaseReconciler: BaseReconciler{
 					Client:                  fakeClient,
-					Scheme:                  &runtime.Scheme{},
+					Scheme:                  fakeClient.Scheme(),
 					APIReader:               fakeClient,
 					logger:                  logger,
 					ReconcililationInterval: 0,
@@ -396,7 +391,6 @@ var _ = Describe("BaseRequestReconciler", Ordered, func() {
 			builder = &builders.BaseBuilder{
 				Client:    fakeClient,
 				Ctx:       ctx,
-				Scheme:    &runtime.Scheme{},
 				APIReader: fakeClient,
 				Template:  template,
 				Request:   request,
@@ -448,7 +442,6 @@ var _ = Describe("BaseRequestReconciler", Ordered, func() {
 			builder = &builders.BaseBuilder{
 				Client:    fakeClient,
 				Ctx:       ctx,
-				Scheme:    &runtime.Scheme{},
 				APIReader: fakeClient,
 				Template:  template,
 				Request:   request,
@@ -502,7 +495,6 @@ var _ = Describe("BaseRequestReconciler", Ordered, func() {
 			builder = &builders.BaseBuilder{
 				Client:    fakeClient,
 				Ctx:       ctx,
-				Scheme:    &runtime.Scheme{},
 				APIReader: fakeClient,
 				Template:  template,
 				Request:   request,
@@ -556,7 +548,6 @@ var _ = Describe("BaseRequestReconciler", Ordered, func() {
 			builder = &builders.BaseBuilder{
 				Client:    fakeClient,
 				Ctx:       ctx,
-				Scheme:    &runtime.Scheme{},
 				APIReader: fakeClient,
 				Template:  template,
 				Request:   request,
@@ -622,7 +613,6 @@ var _ = Describe("BaseRequestReconciler", Ordered, func() {
 				builder = &builders.BaseBuilder{
 					Client:    fakeClient,
 					Ctx:       ctx,
-					Scheme:    &runtime.Scheme{},
 					APIReader: fakeClient,
 					Template:  template,
 					Request:   request,
@@ -687,7 +677,6 @@ var _ = Describe("BaseRequestReconciler", Ordered, func() {
 				builder = &builders.BaseBuilder{
 					Client:    fakeClient,
 					Ctx:       ctx,
-					Scheme:    &runtime.Scheme{},
 					APIReader: fakeClient,
 					Template:  template,
 					Request:   request,
@@ -740,7 +729,6 @@ var _ = Describe("BaseRequestReconciler", Ordered, func() {
 			builder = &builders.BaseBuilder{
 				Client:    fakeClient,
 				Ctx:       ctx,
-				Scheme:    &runtime.Scheme{},
 				APIReader: fakeClient,
 				Template:  template,
 				Request:   request,

--- a/controllers/base_template_controller_test.go
+++ b/controllers/base_template_controller_test.go
@@ -11,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -72,7 +71,6 @@ var _ = Describe("BaseTemplateReconciler", Ordered, func() {
 			r = &BaseTemplateReconciler{
 				BaseReconciler: BaseReconciler{
 					Client:                  fakeClient,
-					Scheme:                  &runtime.Scheme{},
 					APIReader:               fakeClient,
 					logger:                  logger,
 					ReconcililationInterval: 0,
@@ -109,7 +107,6 @@ var _ = Describe("BaseTemplateReconciler", Ordered, func() {
 			builder = &builders.BaseBuilder{
 				Client:    fakeClient,
 				Ctx:       ctx,
-				Scheme:    &runtime.Scheme{},
 				APIReader: fakeClient,
 				Template:  template,
 			}
@@ -153,7 +150,6 @@ var _ = Describe("BaseTemplateReconciler", Ordered, func() {
 			r = &BaseTemplateReconciler{
 				BaseReconciler: BaseReconciler{
 					Client:                  fakeClient,
-					Scheme:                  &runtime.Scheme{},
 					APIReader:               fakeClient,
 					logger:                  logger,
 					ReconcililationInterval: 0,
@@ -164,7 +160,6 @@ var _ = Describe("BaseTemplateReconciler", Ordered, func() {
 			builder = &builders.BaseBuilder{
 				Client:    fakeClient,
 				Ctx:       ctx,
-				Scheme:    &runtime.Scheme{},
 				APIReader: fakeClient,
 				Template:  template,
 			}
@@ -201,7 +196,7 @@ var _ = Describe("BaseTemplateReconciler", Ordered, func() {
 			r = &BaseTemplateReconciler{
 				BaseReconciler: BaseReconciler{
 					Client:                  fakeClient,
-					Scheme:                  &runtime.Scheme{},
+					Scheme:                  fakeClient.Scheme(),
 					APIReader:               fakeClient,
 					logger:                  logger,
 					ReconcililationInterval: 0,
@@ -237,7 +232,6 @@ var _ = Describe("BaseTemplateReconciler", Ordered, func() {
 			builder = &builders.BaseBuilder{
 				Client:    fakeClient,
 				Ctx:       ctx,
-				Scheme:    &runtime.Scheme{},
 				APIReader: fakeClient,
 				Template:  template,
 			}
@@ -287,7 +281,6 @@ var _ = Describe("BaseTemplateReconciler", Ordered, func() {
 			builder = &builders.BaseBuilder{
 				Client:    fakeClient,
 				Ctx:       ctx,
-				Scheme:    &runtime.Scheme{},
 				APIReader: fakeClient,
 				Template:  template,
 			}
@@ -339,7 +332,6 @@ var _ = Describe("BaseTemplateReconciler", Ordered, func() {
 			builder = &builders.BaseBuilder{
 				Client:    fakeClient,
 				Ctx:       ctx,
-				Scheme:    &runtime.Scheme{},
 				APIReader: fakeClient,
 				Template:  template,
 			}
@@ -391,7 +383,6 @@ var _ = Describe("BaseTemplateReconciler", Ordered, func() {
 			builder = &builders.BaseBuilder{
 				Client:    fakeClient,
 				Ctx:       ctx,
-				Scheme:    &runtime.Scheme{},
 				APIReader: fakeClient,
 				Template:  template,
 			}

--- a/controllers/builders/base_builder_test.go
+++ b/controllers/builders/base_builder_test.go
@@ -1,0 +1,205 @@
+package builders
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	api "github.com/diranged/oz/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("BaseBuilder", Ordered, func() {
+	Context("Functions()", func() {
+		var (
+			namespace  *corev1.Namespace
+			deployment *appsv1.Deployment
+			ctx        = context.Background()
+			request    *api.PodAccessRequest
+			template   *api.PodAccessTemplate
+			builder    *BaseBuilder
+		)
+
+		// NOTE: We use a real k8sClient for these tests beacuse we need to
+		// verify things like UID generation happening in the backend, as well
+		// as generation spec updates.
+		BeforeAll(func() {
+			By("Creating the Namespace to perform the tests")
+			namespace = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: randomString(8),
+				},
+			}
+			err := k8sClient.Create(ctx, namespace)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+
+		BeforeEach(func() {
+			// Create a fake deployment target
+			deployment = &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-dep",
+					Namespace: namespace.GetName(),
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"testLabel": "testValue",
+						},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								api.DefaultContainerAnnotationKey: "contb",
+								"Foo":                             "bar",
+							},
+							Labels: map[string]string{
+								"testLabel": "testValue",
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "conta",
+									Image: "nginx:latest",
+								},
+								{
+									Name:  "contb",
+									Image: "nginx:latest",
+								},
+							},
+						},
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, deployment)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Create a default PodAccessTemplate. We'll mutate it for specific tests.
+			template = &api.PodAccessTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-template",
+					Namespace: deployment.Namespace,
+				},
+				Spec: api.PodAccessTemplateSpec{
+					AccessConfig: api.AccessConfig{
+						AllowedGroups:   []string{"testGroupA"},
+						DefaultDuration: "1h",
+						MaxDuration:     "2h",
+					},
+					ControllerTargetRef: &api.CrossVersionObjectReference{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       deployment.Name,
+					},
+					ControllerTargetMutationConfig: &api.PodTemplateSpecMutationConfig{},
+				},
+			}
+			err = k8sClient.Create(ctx, template)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Create a simple PodAccessRequest resource to test the template with
+			request = &api.PodAccessRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-req",
+					Namespace: template.Namespace,
+				},
+				Spec: api.PodAccessRequestSpec{
+					TemplateName: template.Name,
+					Duration:     "5m",
+				},
+			}
+			err = k8sClient.Create(ctx, request)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Create the PodAccessBuilder finally - fully populated with the
+			// Request, Template and fake clients.
+			builder = &BaseBuilder{
+				Client:    k8sClient,
+				Ctx:       ctx,
+				APIReader: k8sClient,
+				Request:   request,
+				Template:  template,
+			}
+		})
+
+		AfterEach(func() {
+			err := k8sClient.Delete(ctx, deployment)
+			Expect(err).To(Not(HaveOccurred()))
+			err = k8sClient.Delete(ctx, request)
+			Expect(err).To(Not(HaveOccurred()))
+			err = k8sClient.Delete(ctx, template)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+
+		It("Get* Funcs should work", func() {
+			Expect(builder.GetClient()).To(Equal(k8sClient))
+			Expect(builder.GetCtx()).To(Equal(ctx))
+			Expect(builder.GetScheme()).To(Equal(k8sClient.Scheme()))
+			Expect(builder.GetTemplate()).To(Equal(template))
+			Expect(builder.GetRequest()).To(Equal(request))
+		})
+
+		It("getShortUID should work", func() {
+			ret := getShortUID(request)
+			Expect(len(ret)).To(Equal(8))
+		})
+
+		It("generateResourceName should work", func() {
+			ret := generateResourceName(request)
+			Expect(len(ret)).To(Equal(17))
+		})
+
+		It("GetTargetRefResource() should return a valid Client.Object", func() {
+			ret, err := builder.GetTargetRefResource()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(ret.GetName()).To(Equal("test-dep"))
+		})
+
+		It("createPod() should work sanely", func() {
+			// Get the PodTemplateSpec
+			pts, err := builder.getPodTemplateFromController()
+			Expect(err).To(Not(HaveOccurred()))
+
+			// First, we should create the pod and return it.
+			pod, err := builder.createPod(pts)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Store the original resourceVersino
+			origResourceVersion := pod.ResourceVersion
+
+			// Mutate the pod ourslves. This simulates a third party resource,
+			// eg, "istio", mutating the pod.
+			pod.ObjectMeta.SetAnnotations(map[string]string{
+				"MyAnnotation":      "bar",
+				"MyOtherAnnotation": "baz",
+			})
+			err = k8sClient.Update(ctx, pod)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// VERIFY: The resourceVersion should have changed
+			postAnnotationUpdateVersion := pod.ResourceVersion
+			Expect(origResourceVersion).To(Not(Equal(postAnnotationUpdateVersion)))
+
+			// Next, re-run the createPod function. We want this function to
+			// never re-create the Pod object once it's been created, or update
+			// it.
+			_, err = builder.createPod(pts)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Re-get the pod from the API
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      pod.Name,
+				Namespace: pod.Namespace,
+			}, pod)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// VERIFY: The Pod resourceVersion has not changed
+			Expect(pod.ObjectMeta.ResourceVersion).To(Equal(postAnnotationUpdateVersion))
+		})
+	})
+})

--- a/controllers/builders/builders_suite_test.go
+++ b/controllers/builders/builders_suite_test.go
@@ -1,8 +1,11 @@
-package builders_test
+package builders
 
 import (
+	"fmt"
+	"math/rand"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -63,3 +66,11 @@ var _ = AfterSuite(func() {
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 })
+
+// Utility function for generating a random string for certain tests
+func randomString(length int) string {
+	rand.Seed(time.Now().UnixNano())
+	b := make([]byte, length)
+	rand.Read(b)
+	return fmt.Sprintf("%x", b)[:length]
+}

--- a/controllers/builders/pod_access_builder_test.go
+++ b/controllers/builders/pod_access_builder_test.go
@@ -11,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -114,7 +113,6 @@ var _ = Describe("PodAccessBuilder", Ordered, func() {
 				BaseBuilder: BaseBuilder{
 					Client:    fakeClient,
 					Ctx:       ctx,
-					Scheme:    &runtime.Scheme{},
 					APIReader: fakeClient,
 					Request:   request,
 					Template:  template,

--- a/controllers/exec_access_request_controller.go
+++ b/controllers/exec_access_request_controller.go
@@ -106,7 +106,6 @@ func (r *ExecAccessRequestReconciler) Reconcile(
 		BaseBuilder: builders.BaseBuilder{
 			Client:    r.Client,
 			Ctx:       ctx,
-			Scheme:    r.Scheme,
 			APIReader: r.APIReader,
 			Request:   resource,
 			Template:  tmpl,

--- a/controllers/exec_access_template_controller.go
+++ b/controllers/exec_access_template_controller.go
@@ -74,7 +74,6 @@ func (r *ExecAccessTemplateReconciler) Reconcile(
 		BaseBuilder: builders.BaseBuilder{
 			Client:   r.Client,
 			Ctx:      ctx,
-			Scheme:   r.Scheme,
 			Template: resource,
 		},
 	}

--- a/controllers/pod_access_request_controller.go
+++ b/controllers/pod_access_request_controller.go
@@ -102,7 +102,6 @@ func (r *PodAccessRequestReconciler) Reconcile(
 		BaseBuilder: builders.BaseBuilder{
 			Client:    r.Client,
 			Ctx:       ctx,
-			Scheme:    r.Scheme,
 			APIReader: r.APIReader,
 			Request:   resource,
 			Template:  tmpl,

--- a/controllers/pod_access_template_controller.go
+++ b/controllers/pod_access_template_controller.go
@@ -74,7 +74,6 @@ func (r *PodAccessTemplateReconciler) Reconcile(
 		BaseBuilder: builders.BaseBuilder{
 			Client:   r.Client,
 			Ctx:      ctx,
-			Scheme:   r.Scheme,
 			Template: resource,
 		},
 	}


### PR DESCRIPTION
Closes #27.

The original code would createOrUpdate the `Pod` resource. The problem is that we were then overwriting the `metadata.annotations` field on updates.

The issue we ran into was this...

1. Oz creates the Pod
2. Istio's Webhook Endpoint mutates the Pod Labels and Annotations
3. Oz's secondary reconcile loop immediately comes in and replaces the metadata.annotations with the original empty annotations
4. Istio doesn't re-apply the annotations because the metadata.labels were mutated and indicate that the webhook has already happened.
5. Istio-validation container won't start up