### PR TITLE
build: replace go vet with golangci-lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,3 +18,8 @@ jobs:
         with:
           path: './...'
           config: revive.toml
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest

--- a/Makefile
+++ b/Makefile
@@ -99,18 +99,18 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 fmt: ## Run go fmt against code.
 	go fmt ./...
 
-.PHONY: vet
-vet: ## Run go vet against code.
-	go vet ./...
+.PHONY: lint
+lint: ## Run golangci-lint against code.
+	golangci-lint run
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
+test: manifests generate fmt lint envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v $(shell go list ./... | grep -v 'e2e') -coverprofile cover.out -covermode=atomic -race
 
 ##@ Build
 
 .PHONY: build
-build: generate fmt vet ## Build manager binary.
+build: generate fmt lint ## Build manager binary.
 	go build -o bin/manager main.go
 
 .PHONY: clean
@@ -118,7 +118,7 @@ clean:
 	rm -rf outputs/*
 
 .PHONY: run
-run: manifests generate fmt vet ## Run a controller from your host.
+run: manifests generate fmt lint ## Run a controller from your host.
 	go run ./main.go
 
 # If you wish built the manager image targeting other platforms you can use the --platform flag.

--- a/Makefile
+++ b/Makefile
@@ -104,13 +104,13 @@ lint: ## Run golangci-lint against code.
 	golangci-lint run
 
 .PHONY: test
-test: manifests generate fmt lint envtest ## Run tests.
+test: manifests generate envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v $(shell go list ./... | grep -v 'e2e') -coverprofile cover.out -covermode=atomic -race
 
 ##@ Build
 
 .PHONY: build
-build: generate fmt lint ## Build manager binary.
+build: generate ## Build manager binary.
 	go build -o bin/manager main.go
 
 .PHONY: clean
@@ -118,7 +118,7 @@ clean:
 	rm -rf outputs/*
 
 .PHONY: run
-run: manifests generate fmt lint ## Run a controller from your host.
+run: manifests generate ## Run a controller from your host.
 	go run ./main.go
 
 # If you wish built the manager image targeting other platforms you can use the --platform flag.

--- a/api/v1alpha1/pod_spec_mutation_config.go
+++ b/api/v1alpha1/pod_spec_mutation_config.go
@@ -186,7 +186,7 @@ func (c *PodTemplateSpecMutationConfig) PatchPodTemplateSpec(
 
 	// By default we purge the Spec.terminationGracePeriodSeconds value.
 	if !c.KeepTerminationGracePeriod {
-		logger.V(1).Info(fmt.Sprintf("Purging spec.terminationGracePeriodSeconds..."))
+		logger.V(1).Info("Purging spec.terminationGracePeriodSeconds...")
 		n.Spec.TerminationGracePeriodSeconds = nil
 	}
 	if !c.KeepLivenessProbe {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/controllers/base_controller.go
+++ b/controllers/base_controller.go
@@ -83,8 +83,12 @@ func (r *BaseReconciler) updateStatus(ctx context.Context, res api.ICoreResource
 		return err
 	}
 
-	// Refetch the object when we're done to make sure we are working with the latest version
-	r.refetch(ctx, res)
+	// Re-fetch the object when we're done to make sure we are working with the latest version
+	if _, err := r.refetch(ctx, res); err != nil {
+		logger.Error(err, "Failed to refetch object")
+		return err
+	}
+
 	logger.V(2).
 		Info("Post Obj Json", "resourceVersion", res.GetResourceVersion(), "json", builders.ObjectToJSON(res))
 

--- a/controllers/base_controller_test.go
+++ b/controllers/base_controller_test.go
@@ -96,7 +96,7 @@ var _ = Describe("BaseReconciler", Ordered, func() {
 			Expect(origResourceVer).To(Not(Equal(newResourceVer)))
 
 			// Now, refetch th data
-			reconciler.refetch(ctx, cm)
+			_, _ = reconciler.refetch(ctx, cm)
 
 			// Verify that the new object has the new resource version
 			Expect(newResourceVer).To(Equal(cm.ResourceVersion))

--- a/controllers/base_request_controller.go
+++ b/controllers/base_request_controller.go
@@ -38,7 +38,8 @@ func (r *BaseRequestReconciler) verifyDuration(builder builders.IBuilder) error 
 	// from lasting indefinitely.
 	var requestedDuration time.Duration
 	if requestedDuration, err = builder.GetRequest().GetDuration(); err != nil {
-		r.updateCondition(
+		// TODO: check err return from updateCondition
+		_ = r.updateCondition(
 			builder.GetCtx(),
 			builder.GetRequest(),
 			ConditionDurationsValid,
@@ -50,7 +51,8 @@ func (r *BaseRequestReconciler) verifyDuration(builder builders.IBuilder) error 
 	}
 	templateDefaultDuration, err := builder.GetTemplate().GetAccessConfig().GetDefaultDuration()
 	if err != nil {
-		r.updateCondition(
+		// TODO: check err return from updateCondition
+		_ = r.updateCondition(
 			builder.GetCtx(),
 			builder.GetRequest(),
 			ConditionDurationsValid,
@@ -63,7 +65,8 @@ func (r *BaseRequestReconciler) verifyDuration(builder builders.IBuilder) error 
 
 	templateMaxDuration, err := builder.GetTemplate().GetAccessConfig().GetMaxDuration()
 	if err != nil {
-		r.updateCondition(
+		// TODO: check err return from updateCondition
+		_ = r.updateCondition(
 			builder.GetCtx(),
 			builder.GetRequest(),
 			ConditionDurationsValid,
@@ -170,7 +173,8 @@ func (r *BaseRequestReconciler) verifyAccessResourcesBuilt(
 
 	statusString, err := builder.GenerateAccessResources()
 	if err != nil {
-		r.updateCondition(
+		// TODO: check err return from updateCondition
+		_ = r.updateCondition(
 			builder.GetCtx(), builder.GetRequest(),
 			ConditionAccessResourcesCreated,
 			metav1.ConditionFalse,
@@ -197,7 +201,8 @@ func (r *BaseRequestReconciler) verifyAccessResourcesReady(
 
 	statusString, err := builder.VerifyAccessResources()
 	if err != nil {
-		r.updateCondition(
+		// TODO: check err return from updateCondition
+		_ = r.updateCondition(
 			builder.GetCtx(), builder.GetRequest(),
 			ConditionAccessResourcesReady,
 			metav1.ConditionFalse,

--- a/controllers/builders/exec_access_builder.go
+++ b/controllers/builders/exec_access_builder.go
@@ -71,7 +71,8 @@ func (b *ExecAccessBuilder) GenerateAccessResources() (statusString string, err 
 		targetPodName,
 	)
 
-	b.Request.SetPodName(targetPodName)
+	// TODO: check err return from SetPodName
+	_ = b.Request.SetPodName(targetPodName)
 	b.Request.Status.SetAccessMessage(accessString)
 
 	return statusString, err

--- a/controllers/builders/pod_access_builder.go
+++ b/controllers/builders/pod_access_builder.go
@@ -94,7 +94,8 @@ func (b *PodAccessBuilder) GenerateAccessResources() (statusString string, err e
 		pod.GetName(),
 	)
 
-	b.Request.SetPodName(pod.GetName())
+	// TODO: check err return from SetPodName
+	_ = b.Request.SetPodName(pod.GetName())
 	b.Request.Status.SetAccessMessage(accessString)
 
 	return statusString, err

--- a/controllers/exec_access_template_controller_test.go
+++ b/controllers/exec_access_template_controller_test.go
@@ -192,7 +192,7 @@ var _ = Describe("ExecAccessTemplateController", Ordered, func() {
 			By("Verifying the resource became ready")
 			Eventually(func() error {
 				found := &api.ExecAccessTemplate{}
-				k8sClient.Get(ctx, types.NamespacedName{
+				_ = k8sClient.Get(ctx, types.NamespacedName{
 					Name:      TestName,
 					Namespace: namespace.Name,
 				}, found)
@@ -278,7 +278,7 @@ var _ = Describe("ExecAccessTemplateController", Ordered, func() {
 			By("Verify that the TargetRefExists condition is False")
 			Eventually(func() error {
 				found := &api.ExecAccessTemplate{}
-				k8sClient.Get(ctx, types.NamespacedName{
+				_ = k8sClient.Get(ctx, types.NamespacedName{
 					Name:      TestName,
 					Namespace: namespace.Name,
 				}, found)
@@ -303,7 +303,7 @@ var _ = Describe("ExecAccessTemplateController", Ordered, func() {
 			By("Verify that the TargetDuration condition is False")
 			Eventually(func() error {
 				found := &api.ExecAccessTemplate{}
-				k8sClient.Get(ctx, types.NamespacedName{
+				_ = k8sClient.Get(ctx, types.NamespacedName{
 					Name:      TestName,
 					Namespace: namespace.Name,
 				}, found)

--- a/controllers/pod_access_template_controller_test.go
+++ b/controllers/pod_access_template_controller_test.go
@@ -207,7 +207,7 @@ var _ = Describe("PodAccessTemplateController", Ordered, func() {
 			By("Verifying the resource became ready")
 			Eventually(func() error {
 				found := &api.PodAccessTemplate{}
-				k8sClient.Get(ctx, types.NamespacedName{
+				_ = k8sClient.Get(ctx, types.NamespacedName{
 					Name:      TestName,
 					Namespace: namespace.Name,
 				}, found)
@@ -291,7 +291,7 @@ var _ = Describe("PodAccessTemplateController", Ordered, func() {
 			By("Verify that the TargetRefExists condition is False")
 			Eventually(func() error {
 				found := &api.PodAccessTemplate{}
-				k8sClient.Get(ctx, types.NamespacedName{
+				_ = k8sClient.Get(ctx, types.NamespacedName{
 					Name:      TestName,
 					Namespace: namespace.Name,
 				}, found)
@@ -316,7 +316,7 @@ var _ = Describe("PodAccessTemplateController", Ordered, func() {
 			By("Verify that the TargetDuration condition is False")
 			Eventually(func() error {
 				found := &api.PodAccessTemplate{}
-				k8sClient.Get(ctx, types.NamespacedName{
+				_ = k8sClient.Get(ctx, types.NamespacedName{
 					Name:      TestName,
 					Namespace: namespace.Name,
 				}, found)

--- a/ozctl/cmd/create.go
+++ b/ozctl/cmd/create.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -22,7 +23,10 @@ var createCmd = &cobra.Command{
 	Args:    cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			cmd.Help()
+			if err := cmd.Help(); err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
 			os.Exit(0)
 		}
 		return nil

--- a/ozctl/cmd/get.go
+++ b/ozctl/cmd/get.go
@@ -1,16 +1,14 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	api "github.com/diranged/oz/api/v1alpha1"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 )
-
-var ourScheme *runtime.Scheme
 
 var getCmd = &cobra.Command{
 	Use:   "get <resource> ...options",
@@ -19,7 +17,10 @@ var getCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			cmd.Help()
+			if err := cmd.Help(); err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
 			os.Exit(0)
 		}
 

--- a/ozctl/cmd/root.go
+++ b/ozctl/cmd/root.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -60,13 +61,19 @@ func Execute() {
 	})
 
 	// Sanity check
-	verifyUsernameSet()
+	if err := verifyUsernameSet(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	// Populate our scopedScheme
 	scopedScheme, _ = api.SchemeBuilder.Build()
 
 	// Make sure to add in our api schemes with the custom resources
-	api.AddToScheme(scheme.Scheme)
+	if err := api.AddToScheme(scheme.Scheme); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	// Set up the root command and make sure that doesn't fail.
 	if err := rootCmd.Execute(); err != nil {
@@ -77,8 +84,7 @@ func Execute() {
 
 func verifyUsernameSet() error {
 	if usernameEnv == "" {
-		fmt.Println("ERROR: This CLI tool requires that the $USER environment be set to something")
-		os.Exit(1)
+		return errors.New("this CLI tool requires that the $USER environment be set to something")
 	}
 	return nil
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -17,25 +17,25 @@ const namespace = "oz-system"
 // Run e2e tests using the Ginkgo runner.
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
-	fmt.Fprintf(GinkgoWriter, "Starting Oz Operator suite\n")
+	_, _ = fmt.Fprintf(GinkgoWriter, "Starting Oz Operator suite\n")
 	RunSpecs(t, "Oz e2e suite")
 }
 
 // Before we start the suite, pre-build the docker image, create the test namespace and get
 // everything spun up.
 var _ = BeforeSuite(func() {
-	cmd := exec.Command("kubectl", "create", "ns", namespace)
+	_ = exec.Command("kubectl", "create", "ns", namespace)
 
-	cmd = exec.Command("make", "release")
-	_, err := utils.Run(cmd)
+	cmdRelease := exec.Command("make", "release")
+	_, err := utils.Run(cmdRelease)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-	cmd = exec.Command("make", "docker-load")
-	_, err = utils.Run(cmd)
+	cmdDockerLoad := exec.Command("make", "docker-load")
+	_, err = utils.Run(cmdDockerLoad)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-	cmd = exec.Command("make", "deploy")
-	_, err = utils.Run(cmd)
+	cmdDeploy := exec.Command("make", "deploy")
+	_, err = utils.Run(cmdDeploy)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	EventuallyWithOffset(1, func() error {

--- a/webhook/contextual_defaulter.go
+++ b/webhook/contextual_defaulter.go
@@ -107,7 +107,10 @@ func (h *defaulterForType) Handle(_ context.Context, req admission.Request) admi
 	// Default the object
 	//
 	// orig: https://github.com/kubernetes-sigs/controller-runtime/blob/v0.13.1/pkg/webhook/admission/defaulter.go#L78-L83
-	obj.Default(req)
+	if err := obj.Default(req); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
 	marshalled, err := json.Marshal(obj)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)


### PR DESCRIPTION
This PR replaces `go vet` in favor of `golangci-lint` which includes `vet` as well as a host of other lint checks. I've also removed `fmt` and `vet` as a required make targets for the build, test, and run targets as code formatting is orthogonal to building the binary.

I've left a few TODOs to handle err responses for areas I wasn't sure about the desired functionality.