### PR TITLE
fix: execaccessrequest was broken due to bogus test code

### DIFF
--- a/api/v1alpha1/exec_access_request_test.go
+++ b/api/v1alpha1/exec_access_request_test.go
@@ -237,7 +237,7 @@ var _ = Describe("ExecAccessRequest", Ordered, func() {
 		err := k8sClient.Create(ctx, namespace)
 		Expect(err).To(Not(HaveOccurred()))
 
-		By("Creating the Deployment to peform the tests")
+		By("Creating the Deployment to perform the tests")
 		deployment = &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-deployment",

--- a/api/v1alpha1/exec_access_request_webhook.go
+++ b/api/v1alpha1/exec_access_request_webhook.go
@@ -17,14 +17,11 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
-	"errors"
 	"fmt"
 
 	"github.com/diranged/oz/webhook"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -55,9 +52,7 @@ var _ webhook.IContextuallyDefaultableObject = &ExecAccessRequest{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *ExecAccessRequest) Default(req admission.Request) error {
-	logger := log.FromContext(context.Background())
-	logger.Info("defaulter Well gotcha", "req", ObjectToJSON(req), "self", ObjectToJSON(r))
-	return errors.New("junk")
+	return nil
 }
 
 //+kubebuilder:webhook:path=/validate-crds-wizardofoz-co-v1alpha1-execaccessrequest,mutating=false,failurePolicy=fail,sideEffects=None,groups=crds.wizardofoz.co,resources=execaccessrequests,verbs=create;update;delete,versions=v1alpha1,name=vexecaccessrequest.kb.io,admissionReviewVersions=v1

--- a/api/v1alpha1/exec_access_request_webhook.go
+++ b/api/v1alpha1/exec_access_request_webhook.go
@@ -51,7 +51,7 @@ func (r *ExecAccessRequest) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.IContextuallyDefaultableObject = &ExecAccessRequest{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *ExecAccessRequest) Default(req admission.Request) error {
+func (r *ExecAccessRequest) Default(_ admission.Request) error {
 	return nil
 }
 

--- a/webhook/contextual_defaulter.go
+++ b/webhook/contextual_defaulter.go
@@ -3,7 +3,10 @@ package webhook
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -107,7 +110,15 @@ func (h *defaulterForType) Handle(_ context.Context, req admission.Request) admi
 	// Default the object
 	//
 	// orig: https://github.com/kubernetes-sigs/controller-runtime/blob/v0.13.1/pkg/webhook/admission/defaulter.go#L78-L83
-	obj.Default(req)
+	err := obj.Default(req)
+	if err != nil {
+		var apiStatus apierrors.APIStatus
+		if errors.As(err, &apiStatus) {
+			return validationResponseFromStatus(false, apiStatus.Status())
+		}
+		return admission.Denied(err.Error())
+	}
+
 	marshalled, err := json.Marshal(obj)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)


### PR DESCRIPTION
while testing some local dev stuff, i broke the execaccessrequest webhook. this was not caught because the contextual defaulter was ignoring the err that was returned.

closes #54 