### PR TITLE
fix: broken release due to dirty zz_generated.deepcopy.go

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,3 +17,6 @@ jobs:
 
       - name: Build Artifacts
         run: make build
+
+      - name: Check for diff?
+        run: git diff --exit-code

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,5 +18,5 @@ jobs:
       - name: Build Artifacts
         run: make build
 
-      - name: Check for diff?
+      - name: Check for diff
         run: git diff --exit-code

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 


### PR DESCRIPTION
The latest release attempt
(https://github.com/diranged/oz/actions/runs/3621310569/jobs/6105202279) failed. In digging in, it looks like in
https://github.com/diranged/oz/pull/53 we made a change to the auto-generated file that was likely done via a IDE or auto-linter.. but that causes the `make build` to mutate the files before the final release, which causes `make release` to fail.

```
diranged@Matts-Air-UW oz % make build
Custom.mk:38: warning: overriding commands for target `lint'
Makefile:104: warning: ignoring old commands for target `lint'
Custom.mk:65: warning: overriding commands for target `fmt'
Makefile:100: warning: ignoring old commands for target `fmt'
Custom.mk:79: warning: overriding commands for target `build'
Makefile:114: warning: ignoring old commands for target `build'
test -s /Users/diranged/go/src/github.com/diranged/oz/bin/controller-gen || GOBIN=/Users/diranged/go/src/github.com/diranged/oz/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.10.0
/Users/diranged/go/src/github.com/diranged/oz/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
PUBLISH=false /Library/Developer/CommandLineTools/usr/bin/make release
Custom.mk:38: warning: overriding commands for target `lint'
Makefile:104: warning: ignoring old commands for target `lint'
Custom.mk:65: warning: overriding commands for target `fmt'
Makefile:100: warning: ignoring old commands for target `fmt'
Custom.mk:79: warning: overriding commands for target `build'
Makefile:114: warning: ignoring old commands for target `build'
IMG=ghcr.io/diranged/oz:0.0.1 /Users/diranged/go/src/github.com/diranged/oz/bin/goreleaser release --skip-publish --snapshot --rm-dist
  • starting release...
  • loading config file                              file=.goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=227eb29e4c6b40278a6eea5fdb86b4287fb8af98 latest tag=0.0.0-rc9
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • running before hooks
    • running                                        hook=go mod tidy
  • snapshotting
    • building snapshot...                           version=0.0.0-rc9-SNAPSHOT-227eb29
  • checking distribution directory
    • --rm-dist is set, cleaning it up
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/cli_darwin_amd64_v1/ozctl
    • building                                       binary=dist/manager_linux_arm64/manager
    • building                                       binary=dist/cli_darwin_arm64/ozctl
    • building                                       binary=dist/manager_linux_amd64_v1/manager
    • took: 3s
  • universal binaries
    • creating from 2 binaries                       binary=dist/cli_darwin_all/ozctl id=cli
  • archives
    • creating                                       archive=dist/oz_0.0.0-rc9-SNAPSHOT-227eb29_darwin_all.tar.gz
    • creating                                       archive=dist/oz_0.0.0-rc9-SNAPSHOT-227eb29_linux_amd64.tar.gz
    • creating                                       archive=dist/oz_0.0.0-rc9-SNAPSHOT-227eb29_linux_arm64.tar.gz
    • took: 8s
  • calculating checksums
  • docker images
    • building docker image                          image=ghcr.io/diranged/oz:0.0.1
    • building docker image                          image=ghcr.io/diranged/oz:0.0.0-rc9-SNAPSHOT-227eb29-amd64
    • building docker image                          image=ghcr.io/diranged/oz:0.0.0-rc9-SNAPSHOT-227eb29-arm64v8
    • took: 3s
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • release succeeded after 13s
diranged@Matts-Air-UW oz % git status
On branch fix_build
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   api/v1alpha1/zz_generated.deepcopy.go

no changes added to commit (use "git add" and/or "git commit -a")
diranged@Matts-Air-UW oz % git diff
diff --git a/api/v1alpha1/zz_generated.deepcopy.go b/api/v1alpha1/zz_generated.deepcopy.go
index b9e85b7..aa3a51c 100644
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1

 import (
-       v1 "k8s.io/api/core/v1"
+       "k8s.io/api/core/v1"
        "k8s.io/apimachinery/pkg/runtime"
 )

diranged@Matts-Air-UW oz %
```