### PR TITLE
chore: new request/template specific status interfaces, and a new package for setting conditions

### DIFF
--- a/API.md
+++ b/API.md
@@ -598,6 +598,12 @@ for storing references to specific Pods that the requestor is being granted acce
 <p>IRequestResource represents a common &ldquo;AccesRequest&rdquo; resource for the Oz Controller. These requests
 have a common set of required methods that are used by the OzRequestReconciler.</p>
 </div>
+<h3 id="crds.wizardofoz.co/v1alpha1.IRequestStatus">IRequestStatus
+</h3>
+<div>
+<p>IRequestStatus is a more specific Status interface that enables getting and
+setting access instruction methods.</p>
+</div>
 <h3 id="crds.wizardofoz.co/v1alpha1.ITemplateResource">ITemplateResource
 </h3>
 <div>
@@ -605,6 +611,12 @@ have a common set of required methods that are used by the OzRequestReconciler.<
 templates provide different types of access into resources (eg, &ldquo;Exec&rdquo; vs &ldquo;Debug&rdquo; vs &ldquo;launch me a
 dedicated pod&rdquo;). A set of common methods are required though that are used by the
 OzTemplateReconciler.</p>
+</div>
+<h3 id="crds.wizardofoz.co/v1alpha1.ITemplateStatus">ITemplateStatus
+</h3>
+<div>
+<p>ITemplateStatus provides a more specific Status interface for Access
+Templates. Functionality to come in the future.</p>
 </div>
 <h3 id="crds.wizardofoz.co/v1alpha1.PodAccessRequest">PodAccessRequest
 </h3>

--- a/internal/api/v1alpha1/core_status.go
+++ b/internal/api/v1alpha1/core_status.go
@@ -4,19 +4,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ICoreStatus is used to define the core common status functions that all Status structs in this
-// API must adhere to. These common functions simplify the reconciler() functions so that they can
-// easily get/set status on the resources in a common way.
-//
-// +kubebuilder:object:generate=false
-type ICoreStatus interface {
-	IsReady() bool
-	SetReady(bool)
-	GetConditions() *[]metav1.Condition
-	SetAccessMessage(string)
-	GetAccessMessage() string
-}
-
 // CoreStatus provides a common set of .Status fields and functions. The goal is to
 // conform to the interfaces.OzResource interface commonly across all of our core CRDs.
 type CoreStatus struct {

--- a/internal/api/v1alpha1/exec_access_request_types.go
+++ b/internal/api/v1alpha1/exec_access_request_types.go
@@ -77,11 +77,7 @@ var (
 	_ IPodRequestResource = (*ExecAccessRequest)(nil)
 )
 
-// GetStatus returns the core Status field for this resource.
-//
-// Returns:
-//
-//	AccessRequestStatus
+// GetStatus implements the ICoreResource interface
 func (r *ExecAccessRequest) GetStatus() ICoreStatus {
 	return &r.Status
 }

--- a/internal/api/v1alpha1/interfaces.go
+++ b/internal/api/v1alpha1/interfaces.go
@@ -18,8 +18,24 @@ type ICoreStatus interface {
 	IsReady() bool
 	SetReady(bool)
 	GetConditions() *[]metav1.Condition
+}
+
+// IRequestStatus is a more specific Status interface that enables getting and
+// setting access instruction methods.
+//
+// +kubebuilder:object:generate=false
+type IRequestStatus interface {
+	ICoreStatus
 	SetAccessMessage(string)
 	GetAccessMessage() string
+}
+
+// ITemplateStatus provides a more specific Status interface for Access
+// Templates. Functionality to come in the future.
+//
+// +kubebuilder:object:generate=false
+type ITemplateStatus interface {
+	ICoreStatus
 }
 
 // The ICoreResource interface wraps a standard client.Object resource (metav1.Object + runtime.Object)
@@ -31,7 +47,7 @@ type ICoreResource interface {
 	metav1.Object
 	runtime.Object
 
-	// Returns back a Status object that matches our OzResourceStatus interface.
+	// Returns a Status object that matches our ICoreStatus interface.
 	GetStatus() ICoreStatus
 }
 

--- a/internal/api/v1alpha1/interfaces.go
+++ b/internal/api/v1alpha1/interfaces.go
@@ -9,6 +9,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ICoreStatus is used to define the core common status functions that all Status structs in this
+// API must adhere to. These common functions simplify the reconciler() functions so that they can
+// easily get/set status on the resources in a common way.
+//
+// +kubebuilder:object:generate=false
+type ICoreStatus interface {
+	IsReady() bool
+	SetReady(bool)
+	GetConditions() *[]metav1.Condition
+	SetAccessMessage(string)
+	GetAccessMessage() string
+}
+
 // The ICoreResource interface wraps a standard client.Object resource (metav1.Object + runtime.Object)
 // with a few additional requirements for common methods that we use throughout our reconciliation process.
 //

--- a/internal/cmd/ozctl/cmd/create_request.go
+++ b/internal/cmd/ozctl/cmd/create_request.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/diranged/oz/internal/api/v1alpha1"
 	api "github.com/diranged/oz/internal/api/v1alpha1"
 )
 
@@ -32,6 +33,9 @@ func createAccessRequest(cmd *cobra.Command, req api.IRequestResource) {
 }
 
 func waitForAccessRequest(cmd *cobra.Command, req api.IRequestResource) {
+	// Cast the ICoreStatus interface into an IRequestStatus interface
+	status := req.GetStatus().(v1alpha1.IRequestStatus)
+
 	// Get our Kubernetes Client
 	client, _ := getKubeClient()
 
@@ -56,14 +60,14 @@ func waitForAccessRequest(cmd *cobra.Command, req api.IRequestResource) {
 		}
 
 		// Check the status
-		if req.GetStatus().IsReady() {
-			cmd.Printf(successMsg, req.GetStatus().GetAccessMessage())
+		if status.IsReady() {
+			cmd.Printf(successMsg, status.GetAccessMessage())
 			break
 		}
 
 		if waitCtx.Err() != nil {
 			fmt.Printf(logError("\nError - timed out waiting for %s to be ready\n"), req.GetName())
-			for _, cond := range *req.GetStatus().GetConditions() {
+			for _, cond := range *status.GetConditions() {
 				cmd.Printf(
 					"Condition %s, State: %s, Reason: %s, Message: %s\n",
 					cond.Type,

--- a/internal/controllers/base_request_controller.go
+++ b/internal/controllers/base_request_controller.go
@@ -41,28 +41,18 @@ func (r *BaseRequestReconciler) verifyDuration(builder builders.IBuilder) error 
 	// from lasting indefinitely.
 	var requestedDuration time.Duration
 	if requestedDuration, err = builder.GetRequest().GetDuration(); err != nil {
-		// TODO: check err return from updateCondition
-		_ = status.UpdateCondition(
-			builder.GetCtx(),
-			r,
-			builder.GetRequest(),
-			v1alpha1.ConditionRequestDurationsValid,
-			metav1.ConditionFalse,
-			string(metav1.StatusReasonBadRequest),
+		// NOTE: Blindly ignoring the error return here because we are already
+		// returning an error which will fail the reconciliation.
+		_ = status.SetRequestDurationsNotValid(builder.GetCtx(), r, builder.GetRequest(),
 			fmt.Sprintf("spec.duration error: %s", err),
 		)
 		return err
 	}
 	templateDefaultDuration, err := builder.GetTemplate().GetAccessConfig().GetDefaultDuration()
 	if err != nil {
-		// TODO: check err return from updateCondition
-		_ = status.UpdateCondition(
-			builder.GetCtx(),
-			r,
-			builder.GetRequest(),
-			v1alpha1.ConditionRequestDurationsValid,
-			metav1.ConditionFalse,
-			string(metav1.StatusReasonBadRequest),
+		// NOTE: Blindly ignoring the error return here because we are already
+		// returning an error which will fail the reconciliation.
+		_ = status.SetRequestDurationsNotValid(builder.GetCtx(), r, builder.GetRequest(),
 			fmt.Sprintf("Template Error, spec.defaultDuration error: %s", err),
 		)
 		return err
@@ -70,14 +60,9 @@ func (r *BaseRequestReconciler) verifyDuration(builder builders.IBuilder) error 
 
 	templateMaxDuration, err := builder.GetTemplate().GetAccessConfig().GetMaxDuration()
 	if err != nil {
-		// TODO: check err return from updateCondition
-		_ = status.UpdateCondition(
-			builder.GetCtx(),
-			r,
-			builder.GetRequest(),
-			v1alpha1.ConditionRequestDurationsValid,
-			metav1.ConditionFalse,
-			string(metav1.StatusReasonBadRequest),
+		// NOTE: Blindly ignoring the error return here because we are already
+		// returning an error which will fail the reconciliation.
+		_ = status.SetRequestDurationsNotValid(builder.GetCtx(), r, builder.GetRequest(),
 			fmt.Sprintf("Template Error, spec.maxDuration error: %s", err),
 		)
 		return err
@@ -106,44 +91,18 @@ func (r *BaseRequestReconciler) verifyDuration(builder builders.IBuilder) error 
 
 		// Log out the decision, and update the condition
 		logger.Info(reasonStr)
-
-		err = status.UpdateCondition(
-			builder.GetCtx(),
-			r,
-			builder.GetRequest(),
-			v1alpha1.ConditionRequestDurationsValid,
-			metav1.ConditionTrue,
-			string(metav1.StatusSuccess),
-			reasonStr,
-		)
-		if err != nil {
+		if err := status.SetRequestDurationsValid(builder.GetCtx(), r, builder.GetRequest(), reasonStr); err != nil {
 			return err
 		}
 	}
 
 	// If the accessUptime is greater than the accessDuration, kill it.
 	if builder.GetRequest().GetUptime() > accessDuration {
-		return status.UpdateCondition(
-			builder.GetCtx(),
-			r,
-			builder.GetRequest(),
-			v1alpha1.ConditionAccessStillValid,
-			metav1.ConditionFalse,
-			string(metav1.StatusReasonTimeout),
-			"Access expired",
-		)
+		return status.SetAccessNotValid(builder.GetCtx(), r, builder.GetRequest())
 	}
 
 	// Update the resource, and let the user know how much time is remaining
-	return status.UpdateCondition(
-		builder.GetCtx(),
-		r,
-		builder.GetRequest(),
-		v1alpha1.ConditionAccessStillValid,
-		metav1.ConditionTrue,
-		string(metav1.StatusSuccess),
-		"Access still valid",
-	)
+	return status.SetAccessStillValid(builder.GetCtx(), r, builder.GetRequest())
 }
 
 // isAccessExpired checks the AccessRequest status for the ConditionAccessStillValid condition. If it is no longer
@@ -203,25 +162,12 @@ func (r *BaseRequestReconciler) verifyAccessResourcesBuilt(
 
 	statusString, err := builder.GenerateAccessResources()
 	if err != nil {
-		// TODO: check err return from updateCondition
-		_ = status.UpdateCondition(
-			builder.GetCtx(),
-			r,
-			builder.GetRequest(),
-			v1alpha1.ConditionAccessResourcesCreated,
-			metav1.ConditionFalse,
-			string(metav1.StatusFailure),
-			fmt.Sprintf("ERROR: %s", err))
+		// NOTE: Blindly ignoring the error return here because we are already
+		// returning an error which will fail the reconciliation.
+		_ = status.SetAccessResourcesNotCreated(builder.GetCtx(), r, builder.GetRequest(), err)
 		return err
 	}
-	return status.UpdateCondition(
-		builder.GetCtx(),
-		r,
-		builder.GetRequest(),
-		v1alpha1.ConditionAccessResourcesCreated,
-		metav1.ConditionTrue,
-		string(metav1.StatusSuccess),
-		statusString)
+	return status.SetAccessResourcesCreated(builder.GetCtx(), r, builder.GetRequest(), statusString)
 }
 
 // verifyAccessResourcesReady is a followup to the verifyAccessResources()
@@ -235,26 +181,13 @@ func (r *BaseRequestReconciler) verifyAccessResourcesReady(
 
 	statusString, err := builder.VerifyAccessResources()
 	if err != nil {
-		// TODO: check err return from updateCondition
-		_ = status.UpdateCondition(
-			builder.GetCtx(),
-			r,
-			builder.GetRequest(),
-			v1alpha1.ConditionAccessResourcesReady,
-			metav1.ConditionFalse,
-			"NotYetReady",
-			fmt.Sprintf("%s", err))
+		// NOTE: Blindly ignoring the error return here because we are already
+		// returning an error which will fail the reconciliation.
+		_ = status.SetAccessResourcesNotReady(builder.GetCtx(), r, builder.GetRequest(), err)
 		return err
 	}
 
-	return status.UpdateCondition(
-		builder.GetCtx(),
-		r,
-		builder.GetRequest(),
-		v1alpha1.ConditionAccessResourcesReady,
-		metav1.ConditionTrue,
-		string(metav1.StatusSuccess),
-		statusString)
+	return status.SetAccessResourcesReady(builder.GetCtx(), r, builder.GetRequest(), statusString)
 }
 
 // DeleteResource just deletes the resource immediately

--- a/internal/controllers/exec_access_request_controller.go
+++ b/internal/controllers/exec_access_request_controller.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -171,19 +170,9 @@ func (r *ExecAccessRequestReconciler) getTargetTemplate(
 
 	if tmpl, err = v1alpha1.GetExecAccessTemplate(ctx, r.Client, req.Spec.TemplateName, req.Namespace); err != nil {
 		// On failure: Update the condition, and return.
-		return nil, status.UpdateCondition(
-			ctx, r, req, v1alpha1.ConditionTargetTemplateExists, metav1.ConditionFalse,
-			string(metav1.StatusReasonNotFound), fmt.Sprintf("Error: %s", err))
+		return nil, status.SetTargetTemplateNotExists(ctx, r, req, err)
 	}
-	return tmpl, status.UpdateCondition(
-		ctx,
-		r,
-		req,
-		v1alpha1.ConditionTargetTemplateExists,
-		metav1.ConditionTrue,
-		string(metav1.StatusSuccess),
-		"Found Target Template",
-	)
+	return tmpl, status.SetTargetTemplateExists(ctx, r, req)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controllers/internal/status/set_conditions.go
+++ b/internal/controllers/internal/status/set_conditions.go
@@ -1,0 +1,271 @@
+package status
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/diranged/oz/internal/api/v1alpha1"
+)
+
+/*
+IRequestResource Condition Setters
+*/
+
+// SetTargetTemplateExists sets the ConditionTargetTemplateExists condition to True
+func SetTargetTemplateExists(
+	ctx context.Context,
+	rec hasStatusReconciler,
+	req v1alpha1.IRequestResource,
+) error {
+	return UpdateCondition(
+		ctx,
+		rec,
+		req,
+		v1alpha1.ConditionTargetTemplateExists,
+		metav1.ConditionTrue,
+		string(metav1.StatusSuccess),
+		"Found Target Template",
+	)
+}
+
+// SetTargetTemplateNotExists sets the ConditionTargetTemplateExists condition to False
+func SetTargetTemplateNotExists(
+	ctx context.Context,
+	rec hasStatusReconciler,
+	req v1alpha1.IRequestResource,
+	err error,
+) error {
+	return UpdateCondition(
+		ctx,
+		rec,
+		req,
+		v1alpha1.ConditionTargetTemplateExists,
+		metav1.ConditionFalse,
+		string(metav1.StatusReasonNotFound),
+		fmt.Sprintf("Error: %s", err),
+	)
+}
+
+// SetRequestDurationsNotValid updates the ConditionRequestDurationsValid
+// condition on a Request resource to a failure.
+func SetRequestDurationsNotValid(
+	ctx context.Context,
+	rec hasStatusReconciler,
+	req v1alpha1.IRequestResource,
+	reason string,
+) error {
+	return UpdateCondition(
+		ctx,
+		rec,
+		req,
+		v1alpha1.ConditionRequestDurationsValid,
+		metav1.ConditionFalse,
+		string(metav1.StatusReasonBadRequest),
+		reason,
+	)
+}
+
+// SetRequestDurationsValid updates the ConditionRequestDurationsValid
+// condition on a Request resource to a success.
+func SetRequestDurationsValid(
+	ctx context.Context,
+	rec hasStatusReconciler,
+	req v1alpha1.IRequestResource,
+	reason string,
+) error {
+	return UpdateCondition(
+		ctx,
+		rec,
+		req,
+		v1alpha1.ConditionRequestDurationsValid,
+		metav1.ConditionTrue,
+		string(metav1.StatusSuccess),
+		reason,
+	)
+}
+
+// SetAccessNotValid updates the ConditionAccessStillValid condition to False.
+func SetAccessNotValid(
+	ctx context.Context,
+	rec hasStatusReconciler,
+	req v1alpha1.IRequestResource,
+) error {
+	return UpdateCondition(
+		ctx,
+		rec,
+		req,
+		v1alpha1.ConditionAccessStillValid,
+		metav1.ConditionFalse,
+		string(metav1.StatusReasonTimeout),
+		"Access expired",
+	)
+}
+
+// SetAccessStillValid updates the ConditionAccessStillValid condition to True.
+func SetAccessStillValid(
+	ctx context.Context,
+	rec hasStatusReconciler,
+	req v1alpha1.IRequestResource,
+) error {
+	return UpdateCondition(
+		ctx,
+		rec,
+		req,
+		v1alpha1.ConditionAccessStillValid,
+		metav1.ConditionTrue,
+		string(metav1.StatusSuccess),
+		"Access still valid",
+	)
+}
+
+// SetAccessResourcesNotCreated updates the ConditionAccessResourcesCreated condition to False.
+func SetAccessResourcesNotCreated(
+	ctx context.Context,
+	rec hasStatusReconciler,
+	req v1alpha1.IRequestResource,
+	err error,
+) error {
+	return UpdateCondition(
+		ctx,
+		rec,
+		req,
+		v1alpha1.ConditionAccessResourcesCreated,
+		metav1.ConditionFalse,
+		string(metav1.StatusFailure),
+		fmt.Sprintf("ERROR: %s", err),
+	)
+}
+
+// SetAccessResourcesCreated updates the ConditionAccessResourcesCreated condition to True.
+func SetAccessResourcesCreated(
+	ctx context.Context,
+	rec hasStatusReconciler,
+	req v1alpha1.IRequestResource,
+	message string,
+) error {
+	return UpdateCondition(
+		ctx,
+		rec,
+		req,
+		v1alpha1.ConditionAccessResourcesCreated,
+		metav1.ConditionTrue,
+		string(metav1.StatusSuccess),
+		message)
+}
+
+// SetAccessResourcesNotReady updates the ConditionAccessResourcesReady condition to False.
+func SetAccessResourcesNotReady(
+	ctx context.Context,
+	rec hasStatusReconciler,
+	req v1alpha1.IRequestResource,
+	err error,
+) error {
+	return UpdateCondition(
+		ctx,
+		rec,
+		req,
+		v1alpha1.ConditionAccessResourcesReady,
+		metav1.ConditionFalse,
+		"NotYetReady",
+		fmt.Sprintf("%s", err),
+	)
+}
+
+// SetAccessResourcesReady updates the ConditionAccessResourcesReady condition to True.
+func SetAccessResourcesReady(
+	ctx context.Context,
+	rec hasStatusReconciler,
+	req v1alpha1.IRequestResource,
+	message string,
+) error {
+	return UpdateCondition(
+		ctx,
+		rec,
+		req,
+		v1alpha1.ConditionAccessResourcesReady,
+		metav1.ConditionTrue,
+		string(metav1.StatusSuccess),
+		message)
+}
+
+/*
+ITemplateResource Condition Setters
+*/
+
+// SetTargetRefExists updates the ConditionTargetRefExists condition on a
+// Template resource to success.
+func SetTargetRefExists(
+	ctx context.Context,
+	rec hasStatusReconciler,
+	tmpl v1alpha1.ITemplateResource,
+	message string,
+) error {
+	return UpdateCondition(
+		ctx,
+		rec,
+		tmpl,
+		v1alpha1.ConditionTargetRefExists,
+		metav1.ConditionTrue,
+		string(metav1.StatusSuccess),
+		message,
+	)
+}
+
+// SetTargetRefNotExists updates the ConditionTargetRefExists condition on a
+// Template resource to a failure based on the Error supplied.
+func SetTargetRefNotExists(
+	ctx context.Context,
+	rec hasStatusReconciler,
+	tmpl v1alpha1.ITemplateResource,
+	err error,
+) error {
+	return UpdateCondition(
+		ctx,
+		rec,
+		tmpl,
+		v1alpha1.ConditionTargetRefExists,
+		metav1.ConditionFalse,
+		string(metav1.StatusReasonNotFound),
+		fmt.Sprintf("Error: %s", err),
+	)
+}
+
+// SetTemplateDurationsNotValid updates the ConditionTemplateDurationsValid
+// condition on a Template resource to a failure.
+func SetTemplateDurationsNotValid(
+	ctx context.Context,
+	rec hasStatusReconciler,
+	tmpl v1alpha1.ITemplateResource,
+	reason string,
+) error {
+	return UpdateCondition(
+		ctx,
+		rec,
+		tmpl,
+		v1alpha1.ConditionTemplateDurationsValid,
+		metav1.ConditionFalse,
+		string(metav1.StatusReasonNotAcceptable),
+		reason,
+	)
+}
+
+// SetTemplateDurationsValid updates the ConditionTemplateDurationsValid
+// condition on a Template resource to a success.
+func SetTemplateDurationsValid(
+	ctx context.Context,
+	rec hasStatusReconciler,
+	tmpl v1alpha1.ITemplateResource,
+	reason string,
+) error {
+	return UpdateCondition(
+		ctx,
+		rec,
+		tmpl,
+		v1alpha1.ConditionTemplateDurationsValid,
+		metav1.ConditionTrue,
+		string(metav1.StatusSuccess),
+		reason,
+	)
+}

--- a/internal/controllers/pod_access_request_controller.go
+++ b/internal/controllers/pod_access_request_controller.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -188,19 +187,9 @@ func (r *PodAccessRequestReconciler) getTargetTemplate(
 	var err error
 	if tmpl, err = v1alpha1.GetPodAccessTemplate(ctx, r.Client, req.Spec.TemplateName, req.Namespace); err != nil {
 		// On failure: Update the condition, and return.
-		return nil, status.UpdateCondition(
-			ctx, r, req, v1alpha1.ConditionTargetTemplateExists, metav1.ConditionFalse,
-			string(metav1.StatusReasonNotFound), fmt.Sprintf("Error: %s", err))
+		return nil, status.SetTargetTemplateNotExists(ctx, r, req, err)
 	}
-	return tmpl, status.UpdateCondition(
-		ctx,
-		r,
-		req,
-		v1alpha1.ConditionTargetTemplateExists,
-		metav1.ConditionTrue,
-		string(metav1.StatusSuccess),
-		"Found Target Template",
-	)
+	return tmpl, status.SetTargetTemplateExists(ctx, r, req)
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
This is mostly code-cleanup in prep for a larger change coming. We create new `IRequestStatus` and `ITemplateStatus` interfaces and move some specific methods into them. We've also moved all of the `UpdateCondition()` calls to the `internal/controllers/internal/status` package - so that the logic is all confined in one place for what types of strings and values are passed into the conditions.