### PR TITLE
fix(pod_watcher): stop following pods/attach calls

### DIFF
--- a/Custom.mk
+++ b/Custom.mk
@@ -82,7 +82,7 @@ build: $(GORELEASER)
 
 .PHONY: docker-load
 docker-load:
-	kind load docker-image $(IMG) -n $(KIND_CLUSTER_NAME)
+	kind load docker-image $(IMG)
 
 gen-crd-api-reference-docs: $(GEN_CRD_API_DOCS)
 $(GEN_CRD_API_DOCS):

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,6 @@ IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.25.0
 
-KIND_CLUSTER_NAME ?= default
-export KIND_CLUSTER_NAME
-
-
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -114,5 +114,4 @@ webhooks:
     - CONNECT
     resources:
     - pods/exec
-    - pods/attach
   sideEffects: None

--- a/internal/controllers/podwatcher/pod_watcher.go
+++ b/internal/controllers/podwatcher/pod_watcher.go
@@ -25,7 +25,7 @@ type PodExecWatcher struct {
 	decoder *admission.Decoder
 }
 
-// +kubebuilder:webhook:path=/watch-v1-pod,mutating=false,failurePolicy=fail,sideEffects=None,groups="",resources=pods/exec;pods/attach,verbs=create;update;connect,versions=v1,name=vpod.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/watch-v1-pod,mutating=false,failurePolicy=fail,sideEffects=None,groups="",resources=pods/exec,verbs=create;update;connect,versions=v1,name=vpod.kb.io,admissionReviewVersions=v1
 
 // Handle logs out each time an Exec/Attach call is made on a pod.
 //


### PR DESCRIPTION
the code currently doesn't support them, which causes an error to be thrown and that blocks the attach call:

```
warning: couldn't attach to pod/debug-diranged-69ef116f, falling back to streaming logs: admission webhook "vpod.kb.io" denied the request: unable to decode /v1, Kind=PodAttachOptions into *v1.PodExecOptions
```

will address this further in a future PR where we add a PodAttachWatcher.