### PR TITLE
feat: add access command to template

### DIFF
--- a/config/crd/bases/crds.wizardofoz.co_execaccessrequests.yaml
+++ b/config/crd/bases/crds.wizardofoz.co_execaccessrequests.yaml
@@ -74,7 +74,7 @@ spec:
               accessMessage:
                 description: "AccessMessage is used to describe to the user how they
                   can make use of their temporary access request. Eg, for a PodAccessTemplate
-                  the value set here would be something like: \n \"Access Graned,
+                  the value set here would be something like: \n \"Access Granted,
                   connect to your pod with: kubectl exec -ti -n namespace pod-xyz
                   -- /bin/bash\""
                 type: string

--- a/config/crd/bases/crds.wizardofoz.co_execaccesstemplates.yaml
+++ b/config/crd/bases/crds.wizardofoz.co_execaccesstemplates.yaml
@@ -46,6 +46,11 @@ spec:
                   has access to the resources this template controls, how long they
                   have access, etc.
                 properties:
+                  accessCommand:
+                    default: /bin/sh
+                    description: AccessCommand is used to describe to the user how
+                      they can make use of their temporary access
+                    type: string
                   allowedGroups:
                     description: AllowedGroups lists out the groups (in string name
                       form) that will be allowed to Exec into the target pod.
@@ -107,7 +112,7 @@ spec:
               accessMessage:
                 description: "AccessMessage is used to describe to the user how they
                   can make use of their temporary access request. Eg, for a PodAccessTemplate
-                  the value set here would be something like: \n \"Access Graned,
+                  the value set here would be something like: \n \"Access Granted,
                   connect to your pod with: kubectl exec -ti -n namespace pod-xyz
                   -- /bin/bash\""
                 type: string

--- a/config/crd/bases/crds.wizardofoz.co_podaccessrequests.yaml
+++ b/config/crd/bases/crds.wizardofoz.co_podaccessrequests.yaml
@@ -69,7 +69,7 @@ spec:
               accessMessage:
                 description: "AccessMessage is used to describe to the user how they
                   can make use of their temporary access request. Eg, for a PodAccessTemplate
-                  the value set here would be something like: \n \"Access Graned,
+                  the value set here would be something like: \n \"Access Granted,
                   connect to your pod with: kubectl exec -ti -n namespace pod-xyz
                   -- /bin/bash\""
                 type: string

--- a/config/crd/bases/crds.wizardofoz.co_podaccesstemplates.yaml
+++ b/config/crd/bases/crds.wizardofoz.co_podaccesstemplates.yaml
@@ -45,6 +45,11 @@ spec:
                   has access to the resources this template controls, how long they
                   have access, etc.
                 properties:
+                  accessCommand:
+                    default: /bin/sh
+                    description: AccessCommand is used to describe to the user how
+                      they can make use of their temporary access
+                    type: string
                   allowedGroups:
                     description: AllowedGroups lists out the groups (in string name
                       form) that will be allowed to Exec into the target pod.
@@ -7453,7 +7458,7 @@ spec:
               accessMessage:
                 description: "AccessMessage is used to describe to the user how they
                   can make use of their temporary access request. Eg, for a PodAccessTemplate
-                  the value set here would be something like: \n \"Access Graned,
+                  the value set here would be something like: \n \"Access Granted,
                   connect to your pod with: kubectl exec -ti -n namespace pod-xyz
                   -- /bin/bash\""
                 type: string

--- a/examples/pod_access_template.yaml
+++ b/examples/pod_access_template.yaml
@@ -13,6 +13,8 @@ spec:
       - admins
       - devs
 
+    accessCommand: '/bin/bash'
+
   controllerTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/internal/api/v1alpha1/access_config.go
+++ b/internal/api/v1alpha1/access_config.go
@@ -29,11 +29,22 @@ type AccessConfig struct {
 	//
 	// +kubebuilder:default:="24h"
 	MaxDuration string `json:"maxDuration"`
+
+	// AccessCommand is used to describe to the user how they can make use of their temporary access
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:="/bin/sh"
+	AccessCommand string `json:"accessCommand"`
 }
 
 // GetAllowedGroups returns the Spec.AllowedGroups for this particular template
 func (a *AccessConfig) GetAllowedGroups() []string {
 	return a.AllowedGroups
+}
+
+// GetAccessCommand returns the Spec.AccessCommand for this particular template
+func (a *AccessConfig) GetAccessCommand() string {
+	return a.AccessCommand
 }
 
 // GetDefaultDuration parses the Spec.defaultDuration field into a time.Duration struct.

--- a/internal/api/v1alpha1/core_status.go
+++ b/internal/api/v1alpha1/core_status.go
@@ -16,7 +16,7 @@ type CoreStatus struct {
 	// AccessMessage is used to describe to the user how they can make use of their temporary access
 	// request. Eg, for a PodAccessTemplate the value set here would be something like:
 	//
-	//   "Access Graned, connect to your pod with: kubectl exec -ti -n namespace pod-xyz -- /bin/bash"
+	//   "Access Granted, connect to your pod with: kubectl exec -ti -n namespace pod-xyz -- /bin/bash"
 	//
 	AccessMessage string `json:"accessMessage,omitempty"`
 }

--- a/internal/api/v1alpha1/exec_access_request_types.go
+++ b/internal/api/v1alpha1/exec_access_request_types.go
@@ -110,6 +110,11 @@ func (r *ExecAccessRequest) GetUptime() time.Duration {
 	return now.Sub(creation)
 }
 
+// GetAccessCommand conforms to the interfaces.OzRequestResource interface
+func (r *ExecAccessRequest) GetAccessCommand() string {
+	return r.Status.AccessMessage
+}
+
 // SetPodName conforms to the interfaces.OzRequestResource interface
 func (r *ExecAccessRequest) SetPodName(name string) error {
 	if r.Status.PodName != "" {

--- a/internal/api/v1alpha1/interfaces.go
+++ b/internal/api/v1alpha1/interfaces.go
@@ -67,7 +67,7 @@ type ITemplateResource interface {
 	GetAccessConfig() *AccessConfig
 }
 
-// IRequestResource represents a common "AccesRequest" resource for the Oz Controller. These requests
+// IRequestResource represents a common "AccessRequest" resource for the Oz Controller. These requests
 // have a common set of required methods that are used by the OzRequestReconciler.
 //
 // +kubebuilder:object:generate=false
@@ -85,6 +85,9 @@ type IRequestResource interface {
 
 	// Returns the uptime in time.Duration() format
 	GetUptime() time.Duration
+
+	// Returns the access command, used to descirbe to user how they can make use of temporary access
+	GetAccessCommand() string
 }
 
 // IPodRequestResource is a Pod-access specific request interface that exposes a few more functions

--- a/internal/api/v1alpha1/pod_access_request_types.go
+++ b/internal/api/v1alpha1/pod_access_request_types.go
@@ -116,6 +116,16 @@ func (r *PodAccessRequest) GetUptime() time.Duration {
 	return now.Sub(creation)
 }
 
+// GetAccessCommand conforms to the interfaces.OzRequestResource interface
+func (r *PodAccessRequest) GetAccessCommand() string {
+	return r.Status.AccessMessage
+}
+
+// SetAccessCommand conforms to the interfaces.OzRequestResource interface
+func (r *PodAccessRequest) SetAccessCommand() string {
+	return r.Status.AccessMessage
+}
+
 // SetPodName conforms to the interfaces.OzRequestResource interface
 func (r *PodAccessRequest) SetPodName(name string) error {
 	if (r.Status.PodName != "") && (r.Status.PodName != name) {

--- a/internal/builders/execaccessbuilder/create_access_resources.go
+++ b/internal/builders/execaccessbuilder/create_access_resources.go
@@ -61,14 +61,11 @@ func (b *ExecAccessBuilder) CreateAccessResources(
 		return statusString, err
 	}
 
-	// Generate the user-friendly information for how to access the pod
-	//
-	// TODO: Templatize this into the ExecAccessTemplate in some way
-	//
 	accessString := fmt.Sprintf(
-		"kubectl exec -ti -n %s %s -- /bin/sh",
+		"kubectl exec -ti -n %s %s -- %s",
 		req.GetNamespace(),
 		targetPodName,
+		execTmpl.Spec.AccessConfig.AccessCommand,
 	)
 	execReq.Status.SetAccessMessage(accessString)
 

--- a/internal/builders/podaccessbuilder/create_access_resources.go
+++ b/internal/builders/podaccessbuilder/create_access_resources.go
@@ -81,15 +81,13 @@ func (b *PodAccessBuilder) CreateAccessResources(
 		return statusString, err
 	}
 
-	// Generate the user-friendly information for how to access the pod
-	//
-	// TODO: Templatize this into the PodAccessTemplate in some way
-	//
 	accessString := fmt.Sprintf(
-		"kubectl exec -ti -n %s %s -- /bin/sh",
+		"kubectl exec -ti -n %s %s -- %s",
 		req.GetNamespace(),
 		pod.GetName(),
+		podTmpl.Spec.AccessConfig.AccessCommand,
 	)
+
 	podReq.Status.SetAccessMessage(accessString)
 
 	// Set the podName (note, just in the local object). If this fails (for

--- a/internal/testing/e2e/e2e_test.go
+++ b/internal/testing/e2e/e2e_test.go
@@ -197,7 +197,7 @@ var _ = Describe("oz-controller", Ordered, func() {
 				Expect(err).To(Not(HaveOccurred()))
 				Expect(
 					message,
-				).To(MatchRegexp("kubectl exec -ti -n oz-system deployment-example-.* -- /bin/sh"))
+				).To(MatchRegexp("kubectl exec -ti -n oz-system deployment-example-.* -- /bin/bash"))
 			})
 		})
 	})


### PR DESCRIPTION
- Add an `accessCommand` to PodAccessTemplate & ExecAccessTemplate which provides an configurable access command to a pod. Omitting this field will default to `bin/sh` in output command

Tested:
```

➜  oz git:(add-access-command) ✗ make release docker-load manifests deploy
➜  oz git:(add-access-command) ✗ kubectl apply -f examples/pod_access_template.yaml
podaccesstemplate.crds.wizardofoz.co/deployment-example created
➜  oz git:(add-access-command) ✗ dist/cli_darwin_arm64/ozctl create podaccessrequest deployment-example
Initiating Access Request...
  Template Name: deployment-example
  Request Name Prefix: dennis
Verifying Template deployment-example exists (ns: default)...
Creating PodAccessRequest... dennis-qqslq created!
Waiting for dennis-qqslq to be ready..
Success, your access request is ready! Here are your access instructions:
---
kubectl exec -ti -n default dennis-qqslq-17ae1645 -- /bin/bash
---

tested that output command results in `bin/sh` if pod_access_template had an omitted field for `accessCommand`
```