### PR TITLE
feat: purge topologySpreadConstraints by default

### DIFF
--- a/API.md
+++ b/API.md
@@ -1282,6 +1282,20 @@ This setting overrides that behavior.</p>
 </tr>
 <tr>
 <td>
+<code>keepTopologySpreadConstraints</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>By default, Oz wipes out the PodSpec
+<a href="https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling"><code>topologySpreadConstraints</code></a>
+configuration for the Pod because these access pods are not part of the
+same group of pods that are passing traffic. This setting overrides that behavior.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>nodeSelector</code><br/>
 <em>
 string

--- a/config/crd/bases/crds.wizardofoz.co_podaccesstemplates.yaml
+++ b/config/crd/bases/crds.wizardofoz.co_podaccesstemplates.yaml
@@ -246,6 +246,12 @@ spec:
                       setting on Pods to ensure that they can be killed as soon as
                       the AccessRequest expires. This flag overrides that behavior.
                     type: boolean
+                  keepTopologySpreadConstraints:
+                    description: By default, Oz wipes out the PodSpec [`topologySpreadConstraints`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling)
+                      configuration for the Pod because these access pods are not
+                      part of the same group of pods that are passing traffic. This
+                      setting overrides that behavior.
+                    type: boolean
                   nodeSelector:
                     additionalProperties:
                       type: string

--- a/internal/api/v1alpha1/pod_spec_mutation_config.go
+++ b/internal/api/v1alpha1/pod_spec_mutation_config.go
@@ -110,6 +110,12 @@ type PodTemplateSpecMutationConfig struct {
 	// +kubebuilder:default:=false
 	KeepStartupProbe bool `json:"keepStartupProbe,omitempty"`
 
+	// By default, Oz wipes out the PodSpec
+	// [`topologySpreadConstraints`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling)
+	// configuration for the Pod because these access pods are not part of the
+	// same group of pods that are passing traffic. This setting overrides that behavior.
+	KeepTopologySpreadConstraints bool `json:"keepTopologySpreadConstraints,omitempty"`
+
 	// If supplied, Oz will insert these
 	// [nodeSelector](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling)
 	// into the target
@@ -210,6 +216,12 @@ func (c *PodTemplateSpecMutationConfig) PatchPodTemplateSpec(
 		logger.V(1).
 			Info(fmt.Sprintf("Purging spec.containers[%d].startupProbe...", defContainerID))
 		n.Spec.Containers[defContainerID].StartupProbe = nil
+	}
+
+	if !c.KeepTopologySpreadConstraints {
+		logger.V(1).
+			Info("Purging spec.topologySpreadConstraints...")
+		n.Spec.TopologySpreadConstraints = nil
 	}
 
 	if c.PurgeAnnotations {

--- a/internal/api/v1alpha1/pod_spec_mutation_config_test.go
+++ b/internal/api/v1alpha1/pod_spec_mutation_config_test.go
@@ -26,6 +26,18 @@ var _ = Describe("PodSpecMutationConfig", Ordered, func() {
 			},
 			Spec: corev1.PodSpec{
 				TerminationGracePeriodSeconds: &termPeriod,
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+					{
+						TopologyKey:       "topology.kubernetes.io/zone",
+						MaxSkew:           1,
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"test": "test",
+							},
+						},
+					},
+				},
 				Containers: []corev1.Container{
 					{
 						Name:  "contA",
@@ -142,6 +154,8 @@ var _ = Describe("PodSpecMutationConfig", Ordered, func() {
 			expectedPodTemplateSpec.Spec.Containers[0].StartupProbe = nil
 			// Wipe: metadata.labels
 			expectedPodTemplateSpec.ObjectMeta.Labels = map[string]string{}
+			// Wipe: topologySpreadConstraints
+			expectedPodTemplateSpec.Spec.TopologySpreadConstraints = nil
 
 			// VERIFY: Unmutated by default
 			Expect(ret.DeepCopy()).To(Equal(expectedPodTemplateSpec))
@@ -150,10 +164,11 @@ var _ = Describe("PodSpecMutationConfig", Ordered, func() {
 		It("PatchPodTemplateSpec should allow skipping the default mutations", func() {
 			// Basic resource with no mutation config
 			config := &PodTemplateSpecMutationConfig{
-				KeepTerminationGracePeriod: true,
-				KeepLivenessProbe:          true,
-				KeepStartupProbe:           true,
-				KeepReadinessProbe:         true,
+				KeepTerminationGracePeriod:    true,
+				KeepLivenessProbe:             true,
+				KeepStartupProbe:              true,
+				KeepReadinessProbe:            true,
+				KeepTopologySpreadConstraints: true,
 			}
 
 			// Run it
@@ -286,6 +301,5 @@ var _ = Describe("PodSpecMutationConfig", Ordered, func() {
 				},
 			))
 		})
-
 	})
 })


### PR DESCRIPTION
When the source template has `.spec.topologySpreadConstraints` set, we almost certainly do not want to keep them - as they tend to reflect labels that are also being purged. By default we will purge these going forward, but provide an option to keep them if desired.