### PR TITLE
feat: add ability to customize security context

### DIFF
--- a/API.md
+++ b/API.md
@@ -1190,6 +1190,22 @@ the annotations, make sure to set the <code>purgeAnnotations</code> flag to <cod
 </tr>
 <tr>
 <td>
+<code>securityContext</code><br/>
+<em>
+<a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#securitycontext-v1-core">
+Kubernetes core/v1.SecurityContext
+</a>
+</em>
+</td>
+<td>
+<p>If supplied, Oz will insert these
+<a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">podsecuritycontext</a>
+into the target
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podtemplatespec-v1-core"><code>SecurityContext</code></a>.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>podLabels</code><br/>
 <em>
 string

--- a/config/crd/bases/crds.wizardofoz.co_podaccesstemplates.yaml
+++ b/config/crd/bases/crds.wizardofoz.co_podaccesstemplates.yaml
@@ -334,6 +334,173 @@ spec:
                           Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  securityContext:
+                    description: If supplied, Oz will insert these [podsecuritycontext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+                      into the target [`SecurityContext`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podtemplatespec-v1-core).
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN Note that this field cannot be set
+                          when spec.os.name is windows.'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false. Note that this field cannot
+                          be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled. Note that this field cannot be set when spec.os.name
+                          is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence. Note
+                          that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options. Note
+                          that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must be set if type is "Localhost". Must NOT
+                              be set for any other type.
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is
+                          linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container. All of a Pod's
+                              containers must have the same effective HostProcess
+                              value (it is not allowed to have a mix of HostProcess
+                              containers and non-HostProcess containers). In addition,
+                              if HostProcess is true then HostNetwork must also be
+                              set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
                 type: object
               controllerTargetRef:
                 description: ControllerTargetRef provides a pattern for referencing

--- a/examples/pod_access_template.yaml
+++ b/examples/pod_access_template.yaml
@@ -29,6 +29,10 @@ spec:
       requests:
         memory: 42Mi
         cpu: 100m
+    securityContext:
+      capabilities:
+        add:
+          - SYS_PTRACE
 
   maxMemory: 1Gi
   maxCpu: 1

--- a/internal/api/v1alpha1/pod_spec_mutation_config.go
+++ b/internal/api/v1alpha1/pod_spec_mutation_config.go
@@ -57,6 +57,12 @@ type PodTemplateSpecMutationConfig struct {
 	PodAnnotations *map[string]string `json:"podAnnotations,omitempty"`
 
 	// If supplied, Oz will insert these
+	// [podsecuritycontext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+	// into the target
+	// [`SecurityContext`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podtemplatespec-v1-core).
+	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
+
+	// If supplied, Oz will insert these
 	// [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
 	// into the target
 	// [`PodTemplateSpec`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podtemplatespec-v1-core).
@@ -232,6 +238,11 @@ func (c *PodTemplateSpecMutationConfig) PatchPodTemplateSpec(
 			logger.V(1).Info(fmt.Sprintf("Setting metadata.annotations.%s: %s", k, v))
 			n.ObjectMeta.Annotations[k] = v
 		}
+	}
+
+	if c.SecurityContext != nil {
+		logger.V(1).Info(fmt.Sprintf("Setting pod security context. %+v", c.SecurityContext))
+		n.Spec.Containers[defContainerID].SecurityContext = c.SecurityContext
 	}
 
 	if c.NodeSelector != nil {

--- a/internal/api/v1alpha1/pod_spec_mutation_config_test.go
+++ b/internal/api/v1alpha1/pod_spec_mutation_config_test.go
@@ -38,6 +38,7 @@ var _ = Describe("PodSpecMutationConfig", Ordered, func() {
 						},
 					},
 				},
+				SecurityContext: &corev1.PodSecurityContext{},
 				Containers: []corev1.Container{
 					{
 						Name:  "contA",
@@ -300,6 +301,25 @@ var _ = Describe("PodSpecMutationConfig", Ordered, func() {
 					"selector": "value",
 				},
 			))
+		})
+
+		It("PatchPodTemplateSpec should pod security context if supplied", func() {
+			// Basic resource with no mutation config
+			sc := &corev1.SecurityContext{
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{"SYS_PTRACE"},
+				},
+			}
+			config := &PodTemplateSpecMutationConfig{
+				SecurityContext: sc,
+			}
+
+			// Run it
+			ret, err := config.PatchPodTemplateSpec(ctx, podTemplateSpec)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// VERIFY: container security context is modified
+			Expect(ret.Spec.Containers[0].SecurityContext).To(Equal(sc))
 		})
 	})
 })

--- a/internal/api/v1alpha1/zz_generated.deepcopy.go
+++ b/internal/api/v1alpha1/zz_generated.deepcopy.go
@@ -496,6 +496,11 @@ func (in *PodTemplateSpecMutationConfig) DeepCopyInto(out *PodTemplateSpecMutati
 			}
 		}
 	}
+	if in.SecurityContext != nil {
+		in, out := &in.SecurityContext, &out.SecurityContext
+		*out = new(v1.SecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.PodLabels != nil {
 		in, out := &in.PodLabels, &out.PodLabels
 		*out = new(map[string]string)


### PR DESCRIPTION
- Looking to add ability to modify security context. 
- Mainly used so we can run vscode python debugger for monolith but ptrace is required https://github.com/microsoft/debugpy/issues/578

manually verified, created podaccessrequest with securitycontext added to mutationconfig in podtemplate
```
    securityContext:
      capabilities:
        add:
        - SYS_PTRACE

```