### PR TITLE
fix(lint): disable the dot-import check

### DIFF
--- a/revive.toml
+++ b/revive.toml
@@ -10,7 +10,6 @@ warningCode = 1
 [rule.blank-imports]
 [rule.context-as-argument]
 [rule.context-keys-type]
-[rule.dot-imports]
 [rule.error-return]
 [rule.error-strings]
 [rule.error-naming]


### PR DESCRIPTION
According to https://google.github.io/styleguide/go/decisions.html#import-dot-import- - this is fine to use as long as we're not in the Google Codebase.