### PR TITLE
feat: add oz prefix name

### DIFF
--- a/internal/cmd/ozctl/cmd/create_exec_access_request.go
+++ b/internal/cmd/ozctl/cmd/create_exec_access_request.go
@@ -108,7 +108,7 @@ func init() {
 	createExecAccessRequestCmd.Flags().
 		StringVarP(&waitTime, "wait", "w", "1m", "Duration to wait for the access request to be fully ready. Valid time units are: ns, us, ms, s, m, h.")
 	createExecAccessRequestCmd.Flags().
-		StringVarP(&requestNamePrefix, "request-name", "N", usernameEnv, "Prefix name to use when creating the `ExecAccessRequest` objects.")
+		StringVarP(&requestNamePrefix, "request-name", "N", fmt.Sprintf("oz-%s", usernameEnv), "Prefix name to use when creating the `ExecAccessRequest` objects.")
 
 	kubeConfigFlags.AddFlags(createExecAccessRequestCmd.Flags())
 

--- a/internal/cmd/ozctl/cmd/create_pod_access_request.go
+++ b/internal/cmd/ozctl/cmd/create_pod_access_request.go
@@ -91,7 +91,7 @@ func init() {
 	createPodAccessRequestCmd.Flags().
 		StringVarP(&waitTime, "wait", "w", "5m", "Duration to wait for the access request to be fully ready. Valid time units are: ns, us, ms, s, m, h.")
 	createPodAccessRequestCmd.Flags().
-		StringVarP(&requestNamePrefix, "request-name", "N", usernameEnv, "Prefix name to use when creating the `AccessRequest` objects.")
+		StringVarP(&requestNamePrefix, "request-name", "N", fmt.Sprintf("oz-%s", usernameEnv), "Prefix name to use when creating the `AccessRequest` objects.")
 
 	kubeConfigFlags.AddFlags(createPodAccessRequestCmd.Flags())
 


### PR DESCRIPTION
- Would like to add an `oz` prefix as the default `request-name`. This would help allow us to filter oz pods from alerts. 