### PR TITLE
fix(ci): use latest 3.x python version

### DIFF
--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.x
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1


### PR DESCRIPTION
Bug: https://github.com/diranged/oz/actions/runs/12802274037/job/35693092033?pr=355
![image](https://github.com/user-attachments/assets/83db9f73-5971-45c5-ace4-ffbd2781ad14)

The Github Team has changed `ubuntu-latest` to point to `24.04` now - and there is no version of Python 3.7 for 24.04 on the x64 arch..